### PR TITLE
Testnet address support (WIP)

### DIFF
--- a/android/src/main/kotlin/io/crossroad/rncardano/Wallet.kt
+++ b/android/src/main/kotlin/io/crossroad/rncardano/Wallet.kt
@@ -44,13 +44,14 @@ class Wallet(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule
 
     @ReactMethod
     fun generateAddresses(
-            account: ReadableMap, type: String, indicies: ReadableArray, promise: Promise
+            account: ReadableMap, type: String, indicies: ReadableArray, protocolMagic: Int, promise: Promise
     ) {
         try {
             val params = JSONObject()
             params.put("account", Convert.json(account))
             params.put("address_type", type)
             params.put("indices", Convert.json(indicies))
+            params.put("protocol_magic", protocolMagic)
             Native.walletGenerateAddresses(params, indicies.size())
                     .map { Convert.arrayResult(it) }
                     .pour(promise)

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare namespace RNCardano {
     
     // Generate addresses for the given wallet.
     export function generateAddresses(
-      account: AccountObj, type: AddressType, indices: Array<number>
+      account: AccountObj, type: AddressType, indices: Array<number>, protocolMagic: number
     ): Promise<Array<Address>>;
 
     // Check if the given base58 string is a valid Cardano Extended Address.

--- a/ios/RNCWallet.m
+++ b/ios/RNCWallet.m
@@ -106,6 +106,7 @@ RCT_EXPORT_METHOD(newAccount:(nonnull NSDictionary *)wallet
 RCT_EXPORT_METHOD(generateAddresses:(nonnull NSDictionary *)account
                   withType:(nonnull NSString*) type
                   forIndices:(nonnull NSArray<NSNumber *> *)indices
+                  withMagic:(nonnull NSNumber*)magic
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     
@@ -141,6 +142,7 @@ RCT_EXPORT_METHOD(generateAddresses:(nonnull NSDictionary *)account
     [params setObject:account forKey:@"account"];
     [params setObject:type forKey:@"address_type"];
     [params setObject:indices forKey:@"indices"];
+    [params setObject:magic forKey:@"protocol_magic"];
     
     [[RNCSafeOperationCombined combine:[RNCSafeOperationCombined combine:op1 with:op2] with:op3] exec:params andResolve:resolve orReject:reject];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-cardano",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "React Native bingings to the rust-cardano",
   "main": "index.js",
   "types": "index.d.ts",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,8 +9,8 @@ keywords = [ "Cardano", "Wallet", "React Native" ]
 [build-dependencies]
 
 [dependencies]
-wallet-wasm = { git = "https://github.com/rooooooooob/js-cardano-wasm.git", branch = "testnet-address-gen" }
-cardano = { git = "https://github.com/rooooooooob/js-cardano-wasm.git", branch = "testnet-address-gen" }
+wallet-wasm = { git = "https://github.com/input-output-hk/js-cardano-wasm.git" }
+cardano = { git = "https://github.com/input-output-hk/js-cardano-wasm.git" }
 
 [target.'cfg(target_os="android")'.dependencies]
 jni = "0.10.2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,8 +9,8 @@ keywords = [ "Cardano", "Wallet", "React Native" ]
 [build-dependencies]
 
 [dependencies]
-wallet-wasm = { git = "https://github.com/ypopovych/js-cardano-wasm.git" }
-cardano = { git = "https://github.com/ypopovych/js-cardano-wasm.git" }
+wallet-wasm = { git = "https://github.com/rooooooooob/js-cardano-wasm.git", branch = "testnet-address-gen" }
+cardano = { git = "https://github.com/rooooooooob/js-cardano-wasm.git", branch = "testnet-address-gen" }
 
 [target.'cfg(target_os="android")'.dependencies]
 jni = "0.10.2"


### PR DESCRIPTION
A simple extension of the API of `generateAddresses` to take in a
protocol magic, allowing testnet address generation.

This was done by simply extending `wallet-wasm` in `js-cardano-wasm` as
it was the simplest solution for now.

As it previously took in JSON for all params the API did not have to
change inside of `android.rs`, `ios.rs`, `rust_native_cardano.h` (or
anything in the `rust/` directory). Same for `android/.../Native.kt`.