### PR TITLE
disable lto for ios targets

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,5 +20,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [profile.release]
 debug = false
-lto = true
 opt-level = 's'
+
+[target.'cfg(target_os="ios")']
+lto = false


### PR DESCRIPTION
We need this in order to be able to build yoroi mobile with `react-native-cardano` and `react-native-chain-libs`.  See discussion in https://www.reddit.com/r/rust/comments/74g6ph/combining_multiple_static_rust_libraries/