### PR TITLE
disable lto for all targets

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,6 +21,4 @@ crate-type = ["staticlib", "cdylib"]
 [profile.release]
 debug = false
 opt-level = 's'
-
-[target.'cfg(target_os="ios")']
 lto = false


### PR DESCRIPTION
As a temporary solution, we may disable lot for _all_ targets. Ideally this must be done only for iOS.